### PR TITLE
lua client driver for KyotoTycoon using its binary protocol at ngx_lua

### DIFF
--- a/README.md
+++ b/README.md
@@ -251,6 +251,7 @@ Core Libraries are bundled in OpenResty package, and you don't need to separatel
 * [lua-resty-mongo](https://github.com/nightsailer/lua-resty-mongo) — Lua mongodb client driver for the ngx_lua based on the cosocket API
 * [lua-mongo](https://github.com/boyxuper/lua-mongo) — A simple Lua Mongo driver (a fork made to work with co-sockets)
 * [lua-resty-kyototycoon](https://github.com/cloudflare/lua-resty-kyototycoon) — Lua client driver for KyotoTycoon using its native wire protocol (OpenResty/ngx_lua)
+* [lua-resty-kyototycoon](https://github.com/sjnam/lua-resty-kyototycoon) — Lua client driver for KyotoTycoon using its binary protocol
 * [lua-resty-tarantool](https://github.com/perusio/lua-resty-tarantool) — Library for working with Tarantool from Nginx with the embedded Lua module or with OpeRresty
 * [lua-nginx-tarantool](https://github.com/ziontab/lua-nginx-tarantool) — A driver for a NoSQL database in a Lua script Tarantool build on fast nginx cosockets
 * [lua-resty-ssdb](https://github.com/LazyZhu/lua-resty-ssdb) — Lua ssdb client driver for the ngx_lua based on the cosocket API, SSDB is a leveldb server


### PR DESCRIPTION
Lua client driver for KyotoTycoon using its binary protocol
