### PR TITLE
Proposing lua-resty-socket

### DIFF
--- a/README.md
+++ b/README.md
@@ -302,6 +302,7 @@ Core Libraries are bundled in OpenResty package, and you don't need to separatel
 * [lua-resty-tsort](https://github.com/bungle/lua-resty-tsort) — Performs a topological sort on input data
 * [lua-resty-postal](https://github.com/bungle/lua-resty-postal) — LuaJIT FFI Bindings to libpostal – a fast statistical parser/normalizer for street addresses around the world.
 * [lua-resty-libinjection](https://github.com/p0pr0ck5/lua-resty-libinjection) — LuaJIT FFI bindings for libinjection, a SQL/SQLi tokenizer and analyzer
+* [lua-resty-socket](https://github.com/thibaultcha/lua-resty-socket) - Automatic LuaSocket/cosockets compatibility module
 
 #### Date and Time
 


### PR DESCRIPTION
Hi there,

I'm not sure if this module belongs to utilities or networking, even less if it belongs to this list at all, actually. 

I have seen several libraries trying to compensate for the lack of support of cosockets in OpenResty's `init` context, and I myself need it for lua-cassandra. 
pgmoon provided a LuaSocket compatibility module for plain Lua (although not for the `init` context and somewhat incomplete). 

Hence, I wrote this lua-resty-socket a few months ago as an iteration over it. It comes very handy when one wants to write his or her lua-resty module as if it were always being used in OpenResty, but with automatic support for the `init` context **and** plain Lua (using LuaSocket/LuaSec).

https://github.com/thibaultcha/lua-resty-socket

(The build is currently failing due to the recent Penlight 1.4 release and busted accepting it over 1.3)

Let me know how you feel about adding it to this list or not.
Cheers
