### PR TITLE
Add inspect.lua

### DIFF
--- a/README.md
+++ b/README.md
@@ -304,6 +304,7 @@ Core Libraries are bundled in OpenResty package, and you don't need to separatel
 * [lua-resty-postal](https://github.com/bungle/lua-resty-postal) — LuaJIT FFI Bindings to libpostal – a fast statistical parser/normalizer for street addresses around the world.
 * [lua-resty-libinjection](https://github.com/p0pr0ck5/lua-resty-libinjection) — LuaJIT FFI bindings for libinjection, a SQL/SQLi tokenizer and analyzer
 * [lua-resty-socket](https://github.com/thibaultcha/lua-resty-socket) - Automatic LuaSocket/cosockets compatibility module
+* [Inspect](https://github.com/kikito/inspect.lua) ([Github](https://github.com/kikito/inspect.lua)) — Inspect is a library that transforms any Lua value into a human-readable representation. It is especially useful for debugging errors in tables.
 
 #### Date and Time
 


### PR DESCRIPTION
This library has been very helpful to me and my team. We used extensively during development.

> Inspect is a library that transforms any Lua value into a human-readable representation. It is especially useful for debugging errors in tables.
