### PR TITLE
Added lua-shdict-nginx-module

### DIFF
--- a/README.md
+++ b/README.md
@@ -372,6 +372,7 @@ Connection utilities for lua-resty-mysql, support for read and write separation�
 * [openresty-statsd](https://github.com/lonelyplanet/openresty-statsd) — A Lua module for OpenResty to send metrics to StatsD
 * [lua-resty-mogilefs](https://github.com/sunkan/lua-resty-mogilefs) — A Lua mogilefs client driver for the ngx_lua based on the cosocket API
 * [lua-resty-etcd](https://github.com/iresty/lua-resty-etcd) — Nonblocking Lua etcd driver library for OpenResty
+* [lua-shdict-nginx-module](https://github.com/rainingmaster/lua-shdict-nginx-module) — An upgraded version of [ngx.shared.DICT](https://github.com/openresty/lua-nginx-module#ngxshareddict), capable of sharing data between `stream` and `http` modules
 
 #### Testing and Profiling
 


### PR DESCRIPTION
I have written a module for shm-based Lua dictionary objects for shared storage. And it runs stably on multiple internal projects. I hope to put it here so that more people can use and upgrade it  together. Thank you.